### PR TITLE
(#5) Make Hoard aware of CRUD + a model's collection

### DIFF
--- a/spec/policy.spec.js
+++ b/spec/policy.spec.js
@@ -8,6 +8,8 @@ describe("Policy", function () {
     beforeEach(function () {
       this.Model = Backbone.Model.extend({url: 'url'});
       this.model = new this.Model({ id: 1, value: 1 });
+      this.collection = new Backbone.Collection();
+      this.collection.add(this.model);
       this.policy = new Policy();
     });
 
@@ -21,6 +23,21 @@ describe("Policy", function () {
 
     it("getData should return the attributes of the given model", function () {
       expect(this.policy.getData(this.model)).to.deep.eql({ id: 1, value: 1 });
+    });
+
+    it("getCollection should return the collection of the given model", function () {
+      expect(this.policy.getData(this.model)).to.deep.eql({ id: 1, value: 1 });
+    });
+
+    it("areModelsSame should return true if the raw models have the same id", function () {
+      expect(this.policy.areModelsSame({ id: 1, v: 1}, { id: 1, v: 2 })).to.be.true;
+      expect(this.policy.areModelsSame({ id: 1, v: 1}, { id: 2, v: 1 })).to.be.false;
+    });
+
+    it("findSameModel should return the model with the same id", function () {
+      var collection = [{ id: 1, v: 1 }, { id: 2, v: 2 }];
+      var model = { id: 2, v: 1 };
+      expect(this.policy.findSameModel(collection, model)).to.deep.eql({ id: 2, v: 2});
     });
   });
 

--- a/src/control.js
+++ b/src/control.js
@@ -93,7 +93,9 @@ _.extend(Control.prototype, Hoard.Events, {
   // The main use of Hoard
   // Return a sync method fully configured for the cache behavior of this Control
   getModelSync: function () {
-    return _.bind(this.sync, this);
+    var modelSync = _.bind(this.sync, this);
+    modelSync.hoardControl = this;
+    return modelSync;
   }
 });
 

--- a/src/create-strategy.js
+++ b/src/create-strategy.js
@@ -3,7 +3,7 @@
 var PositiveWriteStrategy = require('./positive-write-strategy');
 
 module.exports = PositiveWriteStrategy.extend({
-  _method: 'create',
+  method: 'create',
 
   // In standard REST APIs, the id is not available until the response returns.
   // Therefore, use the response when determining how to cache.

--- a/src/delete-strategy.js
+++ b/src/delete-strategy.js
@@ -5,11 +5,12 @@ var Strategy = require('./strategy');
 
 // The Delete Strategy aggressively clears a cached item
 var Delete = Strategy.extend({
-  execute: function (model, options) {
-    var key = this.policy.getKey(model, 'delete');
-    options.url = this.policy.getUrl(model, 'delete', options);
-    var invalidatePromise = this.store.invalidate(key, options);
-    var syncPromise = Hoard.sync('delete', model, options);
+  method: 'delete',
+
+  sync: function (model, options) {
+    var key = this.policy.getKey(model, this.method);
+    var invalidatePromise = this.invalidate(key, options);
+    var syncPromise = Hoard.sync(this.method, model, options);
     var returnSync = function () { return syncPromise; };
     return invalidatePromise.then(returnSync);
   }

--- a/src/patch-strategy.js
+++ b/src/patch-strategy.js
@@ -1,13 +1,18 @@
 'use strict';
 
 var PositiveWriteStrategy = require('./positive-write-strategy');
+var _ = require('underscore');
 
 module.exports = PositiveWriteStrategy.extend({
-  _method: 'patch',
+  method: 'patch',
 
   // A reasonable response for a PATCH call is to return the delta of the update.
   // Provide the original information so the cached data makes sense
   cacheOptions: function (model, options) {
     return { original: this.policy.getData(model, options) };
+  },
+
+  decorateResponse: function (response, options) {
+    return _.extend({}, options.original, response);
   }
 });

--- a/src/policy.js
+++ b/src/policy.js
@@ -34,6 +34,27 @@ _.extend(Policy.prototype, Hoard.Events, {
     return model.toJSON();
   },
 
+  // Get the collection associated with the model
+  getCollection: function (model, options) {
+    return model.collection;
+  },
+
+  // Do two models refer to the same resource?
+  // @param model: the raw model attributes
+  // @param otherModel: the raw model attributes
+  areModelsSame: function (model, otherModel) {
+    return model.id === otherModel.id;
+  },
+
+  // Find the same resource within a collection
+  // @param collection: the raw collection array
+  // @param model: the raw model attributes
+  findSameModel: function (collection, model) {
+    return _.find(collection, function (other) {
+      return this.areModelsSame(model, other);
+    }, this);
+  },
+
   // Generate metadata
   getMetadata: function (key, response, options) {
     var meta = {};

--- a/src/positive-write-strategy.js
+++ b/src/positive-write-strategy.js
@@ -9,9 +9,7 @@ module.exports = Strategy.extend({
   // Cache the response.
   // If cacheOptions.generateKeyFromResponse is true,
   // cache using the key from the response, rather than the request
-  execute: function (model, options) {
-    options.url = this.policy.getUrl(model, this._method, options);
-
+  sync: function (model, options) {
     // Don't consider the sync 'complete' until storage is also complete
     // This ensures that the cache is in sync with the server
     var storeComplete = Hoard.defer();
@@ -20,8 +18,8 @@ module.exports = Strategy.extend({
       onStoreError: storeComplete.reject
     }, options, this.cacheOptions(model, options));
 
-    options.success = this._wrapSuccessWithCache(this._method, model, cacheOptions);
-    Hoard.sync(this._method, model, options);
+    options.success = this._wrapSuccessWithCache(this.method, model, cacheOptions);
+    Hoard.sync(this.method, model, options);
     return storeComplete.promise;
   },
 

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -18,8 +18,104 @@ var Strategy = function (options) {
 _.extend(Strategy.prototype, Hoard.Events, {
   initialize: function () {},
 
+  // Set up some configuration, and pass control to this strategy's sync method
+  // Take care of all caching/server requesting.
+  // This is the main strategy method and entry point from Hoard.Control
   execute: function (model, options) {
-    throw new Error("Strategy#execute must be implemented");
+    options.url = this.policy.getUrl(model, this.method, options);
+    options.collection = this.policy.getCollection(model, options);
+    options.model = model;
+    return this.sync(model, options);
+  },
+
+  // If the model belongs to a collection and that collection is cached,
+  //   first try to read the model from the collection's cache
+  // Default to getting it from the model's cache
+  get: function (key, options) {
+    var updateCollection = this._getUpdateCollection(options);
+    var getFromCache = _.bind(this.store.get, this.store, key, options);
+    if (updateCollection) {
+      return updateCollection().then(
+        function (collection) {
+          var modelResponse = collection.policy.findSameModel(collection.raw, options.model);
+          return modelResponse ? modelResponse : getFromCache();
+        },
+        getFromCache
+      );
+    } else {
+      return getFromCache();
+    }
+  },
+
+  // If the model belongs to a collection and that collection is cached,
+  //   add the model to the collection's cache
+  // Default to setting the model the model's cache
+  set: function (key, value, meta, options) {
+    var updateCollection = this._getUpdateCollection(options);
+    var setToCache = _.bind(this.store.set, this.store, key, value, meta, options);
+    if (updateCollection) {
+      return updateCollection().then(
+        function (collection) {
+          var modelResponse = collection.policy.findSameModel(collection.raw, options.model);
+          if (!modelResponse) {
+            modelResponse = {};
+            collection.raw.push(modelResponse);
+          }
+          // clear the existing model and replace it with the response
+          _.each(_.keys(modelResponse), function (key) {
+            delete modelResponse[key];
+          });
+          _.extend(modelResponse, value);
+          meta = collection.control.policy.getMetadata(collection.key, collection.raw, options);
+          return collection.control.store.set(collection.key, collection.raw, meta, options);
+        },
+        setToCache
+      );
+    } else {
+      return setToCache();
+    }
+  },
+
+  // If the model belongs to a collection and that collection is cached,
+  //   remove the model from the collection's cache
+  // Default to removing the model the model's cache
+  invalidate: function (key, options) {
+    var updateCollection = this._getUpdateCollection(options);
+    var invalidateFromCache = _.bind(this.store.invalidate, this.store, key, options);
+    if (updateCollection) {
+      return updateCollection().then(
+        function (collection) {
+          var filteredCollection = _.reject(collection.raw, function (model) {
+            return collection.policy.areModelsSame(options.model, model);
+          });
+          var meta = collection.control.policy.getMetadata(collection.key, filteredCollection, options);
+          return collection.control.store.set(collection.key, filteredCollection, meta, options);
+        },
+        invalidateFromCache
+      );
+    } else {
+      return invalidateFromCache();
+    }
+  },
+
+  // Return a funtion that accesses the model's collection, if it exists
+  // Otherwise, return undefined, becasues the collection cannot be accessed
+  _getUpdateCollection: function (options) {
+    var collection = options && options.collection;
+    var collectionControl = collection && collection.sync && collection.sync.hoardControl;
+    if (collection && collectionControl) {
+      var collectionKey = collectionControl.policy.getKey(collection, options);
+      return _.bind(function () {
+        return this.store.get(collectionKey, options).then(function (rawCollection) {
+          return {
+            control: collectionControl,
+            policy: collectionControl.policy,
+            key: collectionKey,
+            raw: rawCollection
+          };
+        });
+      }, this);
+    }
   },
 
   //When the cache is full, evict items from the cache
@@ -38,7 +134,7 @@ _.extend(Strategy.prototype, Hoard.Events, {
         var keysToEvict = this.policy.getKeysToEvict(metadata, key, value, error);
         if (!_.isEmpty(keysToEvict)) {
           var evictions = _.map(keysToEvict, function (key) {
-            return this.store.invalidate(key, options);
+            return this.invalidate(key, options);
           }, this);
           return Hoard.Promise.all(evictions);
         } else {
@@ -46,9 +142,15 @@ _.extend(Strategy.prototype, Hoard.Events, {
         }
       }, this));
     }, this)).then(
-      _.bind(this.store.set, this.store, key, value, meta, options),
+      _.bind(this.set, this, key, value, meta, options),
       function () { return Hoard.Promise.reject(value); }
     );
+  },
+
+  // Override to edit the response
+  // Returns the same response by default
+  decorateResponse: function (response, options) {
+    return response;
   },
 
   // Cache the response when the success callback is called
@@ -83,7 +185,7 @@ _.extend(Strategy.prototype, Hoard.Events, {
   },
 
   _invalidateResponse: function (key, response, options) {
-    this.store.invalidate(key).then(
+    this.invalidate(key).then(
       this._storeAction('onStoreSuccess', options, response),
       this._storeAction('onStoreError', options, response)
     );
@@ -91,8 +193,8 @@ _.extend(Strategy.prototype, Hoard.Events, {
 
   _storeResponse: function (key, response, options) {
     var meta = this.policy.getMetadata(key, response, options);
-    var finalResponse = _.extend({}, options.original, response);
-    this.store.set(key, finalResponse, meta).then(
+    var finalResponse = this.decorateResponse(response, options);
+    this.set(key, finalResponse, meta, options).then(
       _.identity,
       _.bind(this.onCacheFull, this)
     ).then(
@@ -103,7 +205,9 @@ _.extend(Strategy.prototype, Hoard.Events, {
 
   _storeAction: function (method, options, response) {
     var callback = options[method] || function () { return response };
-    return function () { return callback(response); }
+    return function () {
+      return callback(response);
+    }
   }
 });
 

--- a/src/update-strategy.js
+++ b/src/update-strategy.js
@@ -2,4 +2,4 @@
 
 var PositiveWriteStrategy = require('./positive-write-strategy');
 
-module.exports = PositiveWriteStrategy.extend({ _method: 'update' });
+module.exports = PositiveWriteStrategy.extend({ method: 'update' });


### PR DESCRIPTION
When Hoard checks for a model's cache existence, and that model has a
collection, Hoard will check that collection's cache for the model.
Similarly, updates and deletes to a model will update the collection's
cache. The implementation currently assumes that a model in a collection
will continue to be accessed via that collection. This results in only
the collection being cached, so the model will have to create a new
cached copy if it is removed from the collection. This should probably
never happen in practice.