### PR TITLE
(#7) Proxy Hoard.extend, so that extend can be overriden once

### DIFF
--- a/spec/extend.spec.js
+++ b/spec/extend.spec.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var Backbone = require('backbone');
+var Hoard = require('src/backbone.hoard');
+var Control = require('src/control');
+var Store = require('src/store');
+var MetaStore = require('src/meta-store');
+var Policy = require('src/policy');
+var Strategy = require('src/strategy');
+
+describe("extend", function () {
+  it("defaults to Backbone.Model.extend", function () {
+    expect(Hoard.extend).to.equal(Backbone.Model.extend);
+  });
+
+  describe("overriding", function () {
+    beforeEach(function () {
+      Hoard.extend = this.sinon.stub();
+    });
+
+    it("Control.extend delegates to Hoard.extend", function () {
+      Control.extend({}, {});
+      expect(Hoard.extend).to.have.been.calledOnce
+        .and.calledWith({}, {});
+    });
+
+    it("Store.extend delegates to Hoard.extend", function () {
+      Store.extend({}, {});
+      expect(Hoard.extend).to.have.been.calledOnce
+        .and.calledWith({}, {});
+    });
+
+    it("MetaStore.extend delegates to Hoard.extend", function () {
+      MetaStore.extend({}, {});
+      expect(Hoard.extend).to.have.been.calledOnce
+        .and.calledWith({}, {});
+    });
+
+    it("Policy.extend delegates to Hoard.extend", function () {
+      Policy.extend({}, {});
+      expect(Hoard.extend).to.have.been.calledOnce
+        .and.calledWith({}, {});
+    });
+
+    it("Strategy.extend delegates to Hoard.extend", function () {
+      Strategy.extend({}, {});
+      expect(Hoard.extend).to.have.been.calledOnce
+        .and.calledWith({}, {});
+    });
+  });
+});

--- a/src/backbone.hoard.js
+++ b/src/backbone.hoard.js
@@ -2,7 +2,7 @@
 
 var Backbone = require('backbone');
 
-module.exports = {
+var Hoard = {
   Promise: function () {
     throw new TypeError('An ES6-compliant Promise implementation must be provided');
   },
@@ -13,6 +13,10 @@ module.exports = {
 
   extend: Backbone.Model.extend,
 
+  _proxyExtend: function () {
+    return Hoard.extend.apply(this, arguments);
+  },
+
   defer: function () {
     var deferred = {};
     deferred.promise = new this.Promise(function (resolve, reject) {
@@ -22,3 +26,5 @@ module.exports = {
     return deferred;
   }
 };
+
+module.exports = Hoard;

--- a/src/control.js
+++ b/src/control.js
@@ -99,6 +99,6 @@ _.extend(Control.prototype, Hoard.Events, {
   }
 });
 
-Control.extend = Hoard.extend;
+Control.extend = Hoard._proxyExtend;
 
 module.exports = Control;

--- a/src/meta-store.js
+++ b/src/meta-store.js
@@ -60,5 +60,5 @@ _.extend(MetaStore.prototype, Hoard.Events, {
   _setItem: StoreHelpers.proxySetItem
 });
 
-MetaStore.extend = Hoard.extend;
+MetaStore.extend = Hoard._proxyExtend;
 module.exports = MetaStore;

--- a/src/policy.js
+++ b/src/policy.js
@@ -81,6 +81,6 @@ _.extend(Policy.prototype, Hoard.Events, {
   }
 });
 
-Policy.extend = Hoard.extend;
+Policy.extend = Hoard._proxyExtend;
 
 module.exports = Policy;

--- a/src/store.js
+++ b/src/store.js
@@ -86,6 +86,6 @@ _.extend(Store.prototype, Hoard.Events, {
   _setItem: StoreHelpers.proxySetItem
 });
 
-Store.extend = Hoard.extend;
+Store.extend = Hoard._proxyExtend;
 
 module.exports = Store;

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -211,6 +211,6 @@ _.extend(Strategy.prototype, Hoard.Events, {
   }
 });
 
-Strategy.extend = Hoard.extend;
+Strategy.extend = Hoard._proxyExtend;
 
 module.exports = Strategy;


### PR DESCRIPTION
This enables the easy use of plugins that override Backbone.Model.extend
(such as backbone-super). Instead of having to overwrite `extend` on
each component, `Hoard.extend` can be overwritten, and every component
will call the new `extend`.