### PR TITLE
(#22) Access to store `backend` is now entirely async

### DIFF
--- a/spec/integration/async-local-storage.js
+++ b/spec/integration/async-local-storage.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var Hoard = require('src/backbone.hoard');
+
+// Wrap localStorage
+module.exports = {
+  setItem: function (key, value) {
+    return Hoard.Promise.resolve().then(function () {
+      return localStorage.setItem(key, value);
+    });
+  },
+
+  getItem: function (key) {
+    return Hoard.Promise.resolve().then(function () {
+      return localStorage.getItem(key);
+    });
+  },
+
+  removeItem: function (key) {
+    return Hoard.Promise.resolve().then(function () {
+      return localStorage.removeItem(key);
+    });
+  }
+};

--- a/spec/integration/read.int-spec.js
+++ b/spec/integration/read.int-spec.js
@@ -4,52 +4,200 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 var Hoard = require('src/backbone.hoard');
 
-describe("Reading", function () {
-  beforeEach(function () {
-    this.control = new Hoard.Control();
-    this.sync = this.control.getModelSync();
-    this.Model = Backbone.Model.extend({
-      idAttribute: 'id',
-      url: function () {
-        return '/id-plus-one/' + this.get('id');
-      },
-      sync: this.sync
-    });
-
-    this.endpoint = /\/id-plus-one\/(.+)/;
-    this.server.respondWith('GET', this.endpoint, function (xhr) {
-      this.storeRequest(xhr);
-      var id = +xhr.url.match(this.endpoint)[1];
-      var value = id + 1;
-
-      if (isNaN(value)) {
-        xhr.respond(400, { 'Content-Type': 'application/json' }, JSON.stringify({
-          id: id,
-          value: 'Feed me numbers'
-        }));
-      } else {
-        xhr.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify({
-          id: id,
-          value: value
-        }));
-      }
-    }.bind(this));
-  });
-
-  describe("multiple times from the same url", function () {
+module.exports = function (storageName, storage) {
+  describe("Reading with " + storageName, function () {
     beforeEach(function () {
-      this.m1 = new this.Model({ id: 1 });
-      this.m2 = new this.Model({ id: 1 });
-    });
-
-    describe("synchronously", function () {
-      beforeEach(function () {
-        this.m1Promise = this.m1.fetch();
-        this.m2Promise = this.m2.fetch();
-        return Promise.all([this.m1Promise, this.m2Promise]);
+      this.sinon.stub(Hoard, 'backend', storage);
+      this.control = new Hoard.Control();
+      this.sync = this.control.getModelSync();
+      this.Model = Backbone.Model.extend({
+        idAttribute: 'id',
+        url: function () {
+          return '/id-plus-one/' + this.get('id');
+        },
+        sync: this.sync
       });
 
-      it("populates all the models with the response", function () {
+      this.endpoint = /\/id-plus-one\/(.+)/;
+      this.server.respondWith('GET', this.endpoint, function (xhr) {
+        this.storeRequest(xhr);
+        var id = +xhr.url.match(this.endpoint)[1];
+        var value = id + 1;
+
+        if (isNaN(value)) {
+          xhr.respond(400, { 'Content-Type': 'application/json' }, JSON.stringify({
+            id: id,
+            value: 'Feed me numbers'
+          }));
+        } else {
+          xhr.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify({
+            id: id,
+            value: value
+          }));
+        }
+      }.bind(this));
+    });
+
+    describe("multiple times from the same url", function () {
+      beforeEach(function () {
+        this.m1 = new this.Model({ id: 1 });
+        this.m2 = new this.Model({ id: 1 });
+      });
+
+      describe("synchronously", function () {
+        beforeEach(function () {
+          this.m1Promise = this.m1.fetch();
+          this.m2Promise = this.m2.fetch();
+          return Promise.all([this.m1Promise, this.m2Promise]);
+        });
+
+        it("populates all the models with the response", function () {
+          expect(this.m1.get('value')).to.equal(2);
+          expect(this.m2.get('value')).to.equal(2);
+        });
+
+        it("only calls the server once", function () {
+          expect(this.requests['GET:/id-plus-one/1']).to.have.length(1);
+        });
+
+        it("doesn't call the server again on subsequent calls", function () {
+          var m3 = new this.Model({ id: 1 });
+          return m3.fetch().then(function () {
+            expect(m3.get('value')).to.equal(2);
+            expect(this.requests['GET:/id-plus-one/1']).to.have.length(1);
+          }.bind(this));
+        });
+
+        it("populates the cache", function () {
+          expect(localStorage.getItem('/id-plus-one/1')).to.equal(JSON.stringify({ id:1, value: 2 }));
+        });
+      });
+
+      describe("asynchronously", function () {
+        beforeEach(function () {
+          var d1 = Hoard.defer();
+          var d2 = Hoard.defer();
+
+          _.defer(function () {
+            this.m1Promise = this.m1.fetch();
+            d1.resolve();
+          }.bind(this));
+
+          _.defer(function () {
+            this.m2Promise = this.m2.fetch();
+            d2.resolve();
+          }.bind(this));
+
+          return Promise.all([d1.prmoise, d2.promise]).then(function () {
+            return Promise.all([this.m1Promise, this.m2Promise]);
+          }.bind(this));
+        });
+
+        it("populates the models with the response", function () {
+          expect(this.m1.get('value')).to.equal(2);
+          expect(this.m2.get('value')).to.equal(2);
+        });
+
+        it("only calls the server once", function () {
+          expect(this.requests['GET:/id-plus-one/1']).to.have.length(1);
+        });
+      });
+
+      describe("with a warmed cache", function () {
+        beforeEach(function () {
+          return this.control.store.set(this.m1.url(), { id: 1, value: 2 }).then(function () {
+            this.m1Promise = this.m1.fetch();
+            this.m2Promise = this.m2.fetch();
+            return Promise.all([this.m1Promise, this.m2Promise]);
+          }.bind(this));
+        });
+
+        it("populates the models with the response", function () {
+          expect(this.m1.get('value')).to.equal(2);
+          expect(this.m2.get('value')).to.equal(2);
+        });
+
+        it("doesn't call the server", function () {
+          expect(this.requests['GET:/id-plus-one/1']).not.to.exist;
+        });
+      });
+    });
+
+    describe("when the request fails", function () {
+      beforeEach(function () {
+        this.notANumber = 'not-a-number';
+        this.m1 = new this.Model({ id: this.notANumber });
+        this.m2 = new this.Model({ id: this.notANumber });
+        return this.m1.fetch().catch(function () {
+          return this.m2.fetch();
+        }.bind(this)).catch(function () {});
+      });
+
+      it("does not populate the models", function () {
+        expect(this.m1.get('value')).to.be.undefined;
+        expect(this.m2.get('value')).to.be.undefined;
+      });
+
+      it("makes multiple calls to the server", function () {
+        expect(this.requests['GET:/id-plus-one/not-a-number']).to.have.length(2);
+      });
+    });
+
+    describe("when the cached value has expired", function () {
+      beforeEach(function () {
+        this.key = '/id-plus-one/1';
+        this.control.store.set(this.key, { id: 1, value: 'super-value' });
+        this.control.store.metaStore.set(this.key, { expires: Date.now() - 1000 });
+        this.m1 = new this.Model({ id: 1 });
+        return this.m1.fetch();
+      });
+
+      it("sets it's value to the server response", function () {
+        expect(this.m1.get('value')).to.equal(2);
+      });
+
+      it("sets the cache to the new value", function () {
+        return expect(this.control.store.get(this.key)).to.eventually.eql({ id: 1, value: 2 });
+      });
+    });
+
+    describe("when the url for the given model changes mid-execution", function () {
+      beforeEach(function () {
+        this.m1 = new this.Model({ id: 1 });
+        var fetch = this.m1.fetch();
+        this.m1.set('id', 2);
+        return fetch;
+      });
+
+      it("uses the url for the model at the start of execution", function () {
+        expect(this.requests['GET:/id-plus-one/1']).to.have.length(1);
+        expect(this.requests['GET:/id-plus-one/2']).to.be.undefined;
+      });
+    });
+
+    describe("when the cache is full", function () {
+      beforeEach(function () {
+        this.key = 'key';
+        return this.control.store.set(this.key, { id: 1, value: 'super-value' }).then(function () {
+          this.sinon.stub(Hoard.backend, 'setItem').throws();
+          this.m1 = new this.Model({ id: 1 });
+          this.m2 = new this.Model({ id: 1 });
+          return Hoard.Promise.all([this.m1.fetch(), this.m2.fetch()]);
+        }.bind(this));
+      });
+
+      // This test depends on a newly deferred function being placed at the end of
+      // the line for execution. This is possibly dependent on the execution environment,
+      // and this test should be made more robust
+      // (possibly through hooks in the code under test) if it ever breaks.
+      it("clears the cache", function (done) {
+        _.defer(function () {
+          expect(this.control.store.get(this.key)).to.be.rejected;
+          done();
+        }.bind(this));
+      });
+
+      it("populates the model", function () {
         expect(this.m1.get('value')).to.equal(2);
         expect(this.m2.get('value')).to.equal(2);
       });
@@ -57,189 +205,44 @@ describe("Reading", function () {
       it("only calls the server once", function () {
         expect(this.requests['GET:/id-plus-one/1']).to.have.length(1);
       });
+    });
 
-      it("doesn't call the server again on subsequent calls", function () {
-        var m3 = new this.Model({ id: 1 });
-        return m3.fetch().then(function () {
-          expect(m3.get('value')).to.equal(2);
+    describe("when the model belongs to a collection", function () {
+      beforeEach(function () {
+        this.collectionKey = '/collection';
+        this.model = new this.Model({ id: 1 });
+        this.Collection = Backbone.Collection.extend({
+          url: this.collectionKey,
+          sync: this.sync
+        });
+        this.collection = new this.Collection();
+
+        this.server.respondWith('GET', '/collection', function (xhr) {
+          this.storeRequest(xhr);
+          xhr.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify([]));
+        }.bind(this));
+
+        return this.collection.fetch().then(function () {
+          this.collection.add(this.model);
+          return this.model.fetch();
+        }.bind(this));
+      });
+
+      it("adds the model under the collection's key", function () {
+        return this.control.store.get(this.collectionKey).then(function (collection) {
+          expect(_.first(collection)).to.deep.eql(this.model.toJSON());
+        }.bind(this));
+      });
+
+      it("can recover the model from the cache", function () {
+        var model = new this.Model({ id: 1 });
+        var collection = new this.Collection(model);
+        return model.fetch().then(function () {
+          expect(model.toJSON()).to.deep.eql(this.model.toJSON());
+          expect(collection.toJSON()).to.deep.eql(this.collection.toJSON());
           expect(this.requests['GET:/id-plus-one/1']).to.have.length(1);
         }.bind(this));
       });
-
-      it("populates the cache", function () {
-        expect(localStorage.getItem('/id-plus-one/1')).to.equal(JSON.stringify({ id:1, value: 2 }));
-      });
-    });
-
-    describe("asynchronously", function () {
-      beforeEach(function () {
-        var d1 = Hoard.defer();
-        var d2 = Hoard.defer();
-
-        _.defer(function () {
-          this.m1Promise = this.m1.fetch();
-          d1.resolve();
-        }.bind(this));
-
-        _.defer(function () {
-          this.m2Promise = this.m2.fetch();
-          d2.resolve();
-        }.bind(this));
-
-        return Promise.all([d1.prmoise, d2.promise]).then(function () {
-          return Promise.all([this.m1Promise, this.m2Promise]);
-        }.bind(this));
-      });
-
-      it("populates the models with the response", function () {
-        expect(this.m1.get('value')).to.equal(2);
-        expect(this.m2.get('value')).to.equal(2);
-      });
-
-      it("only calls the server once", function () {
-        expect(this.requests['GET:/id-plus-one/1']).to.have.length(1);
-      });
-    });
-
-    describe("with a warmed cache", function () {
-      beforeEach(function () {
-        return this.control.store.set(this.m1.url(), { id: 1, value: 2 }).then(function () {
-          this.m1Promise = this.m1.fetch();
-          this.m2Promise = this.m2.fetch();
-          return Promise.all([this.m1Promise, this.m2Promise]);
-        }.bind(this));
-      });
-
-      it("populates the models with the response", function () {
-        expect(this.m1.get('value')).to.equal(2);
-        expect(this.m2.get('value')).to.equal(2);
-      });
-
-      it("doesn't call the server", function () {
-        expect(this.requests['GET:/id-plus-one/1']).not.to.exist;
-      });
     });
   });
-
-  describe("when the request fails", function () {
-    beforeEach(function () {
-      this.notANumber = 'not-a-number';
-      this.m1 = new this.Model({ id: this.notANumber });
-      this.m2 = new this.Model({ id: this.notANumber });
-      return this.m1.fetch().catch(function () {
-        return this.m2.fetch();
-      }.bind(this)).catch(function () {});
-    });
-
-    it("does not populate the models", function () {
-      expect(this.m1.get('value')).to.be.undefined;
-      expect(this.m2.get('value')).to.be.undefined;
-    });
-
-    it("makes multiple calls to the server", function () {
-      expect(this.requests['GET:/id-plus-one/not-a-number']).to.have.length(2);
-    });
-  });
-
-  describe("when the cached value has expired", function () {
-    beforeEach(function () {
-      this.key = '/id-plus-one/1';
-      this.control.store.set(this.key, { id: 1, value: 'super-value' });
-      this.control.store.metaStore.set(this.key, { expires: Date.now() - 1000 });
-      this.m1 = new this.Model({ id: 1 });
-      return this.m1.fetch();
-    });
-
-    it("sets it's value to the server response", function () {
-      expect(this.m1.get('value')).to.equal(2);
-    });
-
-    it("sets the cache to the new value", function () {
-      return expect(this.control.store.get(this.key)).to.eventually.eql({ id: 1, value: 2 });
-    });
-  });
-
-  describe("when the url for the given model changes mid-execution", function () {
-    beforeEach(function () {
-      this.m1 = new this.Model({ id: 1 });
-      var fetch = this.m1.fetch();
-      this.m1.set('id', 2);
-      return fetch;
-    });
-
-    it("uses the url for the model at the start of execution", function () {
-      expect(this.requests['GET:/id-plus-one/1']).to.have.length(1);
-      expect(this.requests['GET:/id-plus-one/2']).to.be.undefined;
-    });
-  });
-
-  describe("when the cache is full", function () {
-    beforeEach(function () {
-      this.key = 'key';
-      return this.control.store.set(this.key, { id: 1, value: 'super-value' }).then(function () {
-        this.sinon.stub(Hoard.backend, 'setItem').throws();
-        this.m1 = new this.Model({ id: 1 });
-        this.m2 = new this.Model({ id: 1 });
-        return Hoard.Promise.all([this.m1.fetch(), this.m2.fetch()]);
-      }.bind(this));
-    });
-
-    // This test depends on a newly deferred function being placed at the end of
-    // the line for execution. This is possibly dependent on the execution environment,
-    // and this test should be made more robust
-    // (possibly through hooks in the code under test) if it ever breaks.
-    it("clears the cache", function (done) {
-      _.defer(function () {
-        expect(this.control.store.get(this.key)).to.be.rejected;
-        done();
-      }.bind(this));
-    });
-
-    it("populates the model", function () {
-      expect(this.m1.get('value')).to.equal(2);
-      expect(this.m2.get('value')).to.equal(2);
-    });
-
-    it("only calls the server once", function () {
-      expect(this.requests['GET:/id-plus-one/1']).to.have.length(1);
-    });
-  });
-
-  describe("when the model belongs to a collection", function () {
-    beforeEach(function () {
-      this.collectionKey = '/collection';
-      this.model = new this.Model({ id: 1 });
-      this.Collection = Backbone.Collection.extend({
-        url: this.collectionKey,
-        sync: this.sync
-      });
-      this.collection = new this.Collection();
-
-      this.server.respondWith('GET', '/collection', function (xhr) {
-        this.storeRequest(xhr);
-        xhr.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify([]));
-      }.bind(this));
-
-      return this.collection.fetch().then(function () {
-        this.collection.add(this.model);
-        return this.model.fetch();
-      }.bind(this));
-    });
-
-    it("adds the model under the collection's key", function () {
-      return this.control.store.get(this.collectionKey).then(function (collection) {
-        expect(_.first(collection)).to.deep.eql(this.model.toJSON());
-      }.bind(this));
-    });
-
-    it("can recover the model from the cache", function () {
-      var model = new this.Model({ id: 1 });
-      var collection = new this.Collection(model);
-      return model.fetch().then(function () {
-        expect(model.toJSON()).to.deep.eql(this.model.toJSON());
-        expect(collection.toJSON()).to.deep.eql(this.collection.toJSON());
-        expect(this.requests['GET:/id-plus-one/1']).to.have.length(1);
-      }.bind(this));
-    });
-  });
-});
+};

--- a/spec/integration/setup.js
+++ b/spec/integration/setup.js
@@ -8,17 +8,22 @@ var sinonChai = require('sinon-chai');
 var chaiAsPromised = require('chai-as-promised');
 var Backbone = require('backbone');
 var Hoard = require('src/build/backbone.hoard.bundle');
+var asyncLocalStorage = require('./async-local-storage');
 
 // load specs
-require('./read.int-spec.js');
-require('./write.int-spec.js');
+var readSpecs = require('./read.int-spec.js');
+var writeSpecs = require('./write.int-spec.js');
+
+readSpecs('localStorage', localStorage);
+writeSpecs('localStorage', localStorage);
+readSpecs('asyncLocalStorage', asyncLocalStorage);
+writeSpecs('asyncLocalStorage', asyncLocalStorage);
 
 window.expect = chai.expect;
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
 
 beforeEach(function () {
-  Hoard.backend.clear();
   this.server = sinon.fakeServer.create();
   this.server.autoRespond = true;
   this.sinon = sinon.sandbox.create();
@@ -36,4 +41,5 @@ beforeEach(function () {
 afterEach(function () {
   this.server.restore();
   this.sinon.restore();
+  localStorage.clear();
 });

--- a/spec/integration/write.int-spec.js
+++ b/spec/integration/write.int-spec.js
@@ -4,256 +4,259 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 var Hoard = require('src/backbone.hoard');
 
-describe("Writing", function () {
-  beforeEach(function () {
-    this.control = new Hoard.Control();
-    this.urlRoot = '/models';
-    this.sync = this.control.getModelSync();
-    this.Model = Backbone.Model.extend({
-      urlRoot: this.urlRoot,
-      sync: this.sync
-    });
-
-    this.collectionKey = '/collection';
-    this.Collection = Backbone.Collection.extend({
-      url: this.collectionKey,
-      sync: this.sync
-    });
-
-    //NOTE: This server setup demonstrates a case where you should not use Hoard,
-    // or at the very least you should implement a custom set of strategies
-    this.server.respondWith('GET', '/models/1', function (xhr) {
-      this.storeRequest(xhr);
-      xhr.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify({ id: -1, value: -1 }));
-    }.bind(this));
-
-    this.model = new this.Model({ value: 1 });
-  });
-
-  describe("saving a new model", function () {
+module.exports = function (storageName, storage) {
+  describe("Writing with " + storageName, function () {
     beforeEach(function () {
-      this.server.respondWith('POST', this.urlRoot, function (xhr) {
+      this.sinon.stub(Hoard, 'backend', storage);
+      this.control = new Hoard.Control();
+      this.urlRoot = '/models';
+      this.sync = this.control.getModelSync();
+      this.Model = Backbone.Model.extend({
+        urlRoot: this.urlRoot,
+        sync: this.sync
+      });
+
+      this.collectionKey = '/collection';
+      this.Collection = Backbone.Collection.extend({
+        url: this.collectionKey,
+        sync: this.sync
+      });
+
+      //NOTE: This server setup demonstrates a case where you should not use Hoard,
+      // or at the very least you should implement a custom set of strategies
+      this.server.respondWith('GET', '/models/1', function (xhr) {
         this.storeRequest(xhr);
-        var model = JSON.parse(xhr.requestBody);
-        _.extend(model, { id: model.value });
-        xhr.respond(201, { 'Content-Type': 'application/json' }, JSON.stringify(model));
+        xhr.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify({ id: -1, value: -1 }));
       }.bind(this));
+
+      this.model = new this.Model({ value: 1 });
     });
 
-    describe("for a standalone model", function () {
+    describe("saving a new model", function () {
       beforeEach(function () {
-        return this.model.save();
-      });
-
-      it("populates the model with the response", function () {
-        expect(this.model.get('id')).to.equal(1);
-        expect(this.model.get('value')).to.equal(1);
-      });
-
-      it("populates the cache", function () {
-        return expect(this.control.store.get('/models/1')).to.eventually.eql({ id: 1, value: 1 });
-      });
-
-      it("allows future fetches to read from the cache", function () {
-        var model2 = new this.Model({id: 1});
-        return model2.fetch().then(function () {
-          expect(model2.get('id')).to.equal(1);
-          expect(model2.get('value')).to.equal(1);
-          expect(this.requests['GET:/models/1']).to.be.undefined;
+        this.server.respondWith('POST', this.urlRoot, function (xhr) {
+          this.storeRequest(xhr);
+          var model = JSON.parse(xhr.requestBody);
+          _.extend(model, { id: model.value });
+          xhr.respond(201, { 'Content-Type': 'application/json' }, JSON.stringify(model));
         }.bind(this));
       });
-    });
 
-    describe("for a model in a collection", function () {
-      beforeEach(function () {
-        this.collection = new this.Collection(this.model);
-        this.initialData = [];
-        return this.control.store.set(this.collectionKey, this.initialData).then(function () {
+      describe("for a standalone model", function () {
+        beforeEach(function () {
           return this.model.save();
-        }.bind(this));
-      });
-
-      it("updates the model in the collection", function () {
-        var collection = new this.Collection();
-        return collection.fetch().then(function () {
-          expect(collection.toJSON()).to.deep.eql([{ id: 1, value: 1 }]);
         });
-      });
-    });
-  });
 
-  describe("updating an existing model", function () {
-    beforeEach(function () {
-      this.server.respondWith('PUT', '/models/1', function (xhr) {
-        this.storeRequest(xhr);
-        var model = JSON.parse(xhr.requestBody);
-        _.extend(model, { updated: true });
-        xhr.respond(201, { 'Content-Type': 'application/json' }, JSON.stringify(model));
-      }.bind(this));
+        it("populates the model with the response", function () {
+          expect(this.model.get('id')).to.equal(1);
+          expect(this.model.get('value')).to.equal(1);
+        });
 
-      this.model.set('id', 1);
-    });
+        it("populates the cache", function () {
+          return expect(this.control.store.get('/models/1')).to.eventually.eql({ id: 1, value: 1 });
+        });
 
-    describe("for a standalone model", function () {
-      beforeEach(function () {
-        return this.model.save();
-      });
-
-      it("populates the model with the response", function () {
-        expect(this.model.get('id')).to.equal(1);
-        expect(this.model.get('value')).to.equal(1);
-        expect(this.model.get('updated')).to.be.true;
-      });
-
-      it("populates the cache", function () {
-        return expect(this.control.store.get('/models/1')).to.eventually.eql({
-          id: 1,
-          value: 1,
-          updated: true
+        it("allows future fetches to read from the cache", function () {
+          var model2 = new this.Model({id: 1});
+          return model2.fetch().then(function () {
+            expect(model2.get('id')).to.equal(1);
+            expect(model2.get('value')).to.equal(1);
+            expect(this.requests['GET:/models/1']).to.be.undefined;
+          }.bind(this));
         });
       });
 
-      it("allows future fetches to read from the cache", function () {
-        var model2 = new this.Model({id: 1});
-        return model2.fetch().then(function () {
-          expect(model2.get('id')).to.equal(1);
-          expect(model2.get('value')).to.equal(1);
-          expect(model2.get('updated')).to.be.true;
-          expect(this.requests['GET:/models/1']).to.be.undefined;
-        }.bind(this));
+      describe("for a model in a collection", function () {
+        beforeEach(function () {
+          this.collection = new this.Collection(this.model);
+          this.initialData = [];
+          return this.control.store.set(this.collectionKey, this.initialData).then(function () {
+            return this.model.save();
+          }.bind(this));
+        });
+
+        it("updates the model in the collection", function () {
+          var collection = new this.Collection();
+          return collection.fetch().then(function () {
+            expect(collection.toJSON()).to.deep.eql([{ id: 1, value: 1 }]);
+          });
+        });
       });
     });
 
-    describe("for a model in a collection", function () {
+    describe("updating an existing model", function () {
       beforeEach(function () {
-        this.collection = new this.Collection(this.model);
-        this.initialData = [{ id: 1 }];
-        return this.control.store.set(this.collectionKey, this.initialData).then(function () {
-          return this.model.save();
+        this.server.respondWith('PUT', '/models/1', function (xhr) {
+          this.storeRequest(xhr);
+          var model = JSON.parse(xhr.requestBody);
+          _.extend(model, { updated: true });
+          xhr.respond(201, { 'Content-Type': 'application/json' }, JSON.stringify(model));
         }.bind(this));
+
+        this.model.set('id', 1);
       });
 
-      it("updates the model in the collection", function () {
-        var collection = new this.Collection();
-        return collection.fetch().then(function () {
-          expect(collection.toJSON()).to.deep.eql([{
+      describe("for a standalone model", function () {
+        beforeEach(function () {
+          return this.model.save();
+        });
+
+        it("populates the model with the response", function () {
+          expect(this.model.get('id')).to.equal(1);
+          expect(this.model.get('value')).to.equal(1);
+          expect(this.model.get('updated')).to.be.true;
+        });
+
+        it("populates the cache", function () {
+          return expect(this.control.store.get('/models/1')).to.eventually.eql({
             id: 1,
             value: 1,
             updated: true
-          }]);
+          });
+        });
+
+        it("allows future fetches to read from the cache", function () {
+          var model2 = new this.Model({id: 1});
+          return model2.fetch().then(function () {
+            expect(model2.get('id')).to.equal(1);
+            expect(model2.get('value')).to.equal(1);
+            expect(model2.get('updated')).to.be.true;
+            expect(this.requests['GET:/models/1']).to.be.undefined;
+          }.bind(this));
+        });
+      });
+
+      describe("for a model in a collection", function () {
+        beforeEach(function () {
+          this.collection = new this.Collection(this.model);
+          this.initialData = [{ id: 1 }];
+          return this.control.store.set(this.collectionKey, this.initialData).then(function () {
+            return this.model.save();
+          }.bind(this));
+        });
+
+        it("updates the model in the collection", function () {
+          var collection = new this.Collection();
+          return collection.fetch().then(function () {
+            expect(collection.toJSON()).to.deep.eql([{
+              id: 1,
+              value: 1,
+              updated: true
+            }]);
+          });
         });
       });
     });
-  });
 
-  describe("patching an existing model", function () {
-    beforeEach(function () {
-      this.server.respondWith('PATCH', '/models/1', function (xhr) {
-        this.storeRequest(xhr);
-        var model = JSON.parse(xhr.requestBody);
-        _.extend(model, { patched: true });
-        xhr.respond(201, { 'Content-Type': 'application/json' }, JSON.stringify(model));
-      }.bind(this));
-
-      this.model.set('id', 1);
-    });
-
-    describe("for a standalone model", function () {
+    describe("patching an existing model", function () {
       beforeEach(function () {
-        return this.model.save({}, { patch: true });
-      });
-
-      it("populates the model with the response", function () {
-        expect(this.model.get('id')).to.equal(1);
-        expect(this.model.get('value')).to.equal(1);
-        expect(this.model.get('patched')).to.be.true;
-      });
-
-      it("populates the cache", function () {
-        return expect(this.control.store.get('/models/1')).to.eventually.eql({
-          id: 1,
-          value: 1,
-          patched: true
-        });
-      });
-
-      it("allows future fetches to read from the cache", function () {
-        var model2 = new this.Model({id: 1});
-        return model2.fetch().then(function () {
-          expect(model2.get('id')).to.equal(1);
-          expect(model2.get('value')).to.equal(1);
-          expect(model2.get('patched')).to.be.true;
-          expect(this.requests['GET:/models/1']).to.be.undefined;
+        this.server.respondWith('PATCH', '/models/1', function (xhr) {
+          this.storeRequest(xhr);
+          var model = JSON.parse(xhr.requestBody);
+          _.extend(model, { patched: true });
+          xhr.respond(201, { 'Content-Type': 'application/json' }, JSON.stringify(model));
         }.bind(this));
-      });
-    });
 
-    describe("for a model in a collection", function () {
-      beforeEach(function () {
-        this.collection = new this.Collection(this.model);
-        this.initialData = [{ id: 1 }];
-        return this.control.store.set(this.collectionKey, this.initialData).then(function () {
+        this.model.set('id', 1);
+      });
+
+      describe("for a standalone model", function () {
+        beforeEach(function () {
           return this.model.save({}, { patch: true });
-        }.bind(this));
-      });
+        });
 
-      it("updates the model in the collection", function () {
-        var collection = new this.Collection();
-        return collection.fetch().then(function () {
-          expect(collection.toJSON()).to.deep.eql([{
+        it("populates the model with the response", function () {
+          expect(this.model.get('id')).to.equal(1);
+          expect(this.model.get('value')).to.equal(1);
+          expect(this.model.get('patched')).to.be.true;
+        });
+
+        it("populates the cache", function () {
+          return expect(this.control.store.get('/models/1')).to.eventually.eql({
             id: 1,
             value: 1,
             patched: true
-          }]);
+          });
+        });
+
+        it("allows future fetches to read from the cache", function () {
+          var model2 = new this.Model({id: 1});
+          return model2.fetch().then(function () {
+            expect(model2.get('id')).to.equal(1);
+            expect(model2.get('value')).to.equal(1);
+            expect(model2.get('patched')).to.be.true;
+            expect(this.requests['GET:/models/1']).to.be.undefined;
+          }.bind(this));
+        });
+      });
+
+      describe("for a model in a collection", function () {
+        beforeEach(function () {
+          this.collection = new this.Collection(this.model);
+          this.initialData = [{ id: 1 }];
+          return this.control.store.set(this.collectionKey, this.initialData).then(function () {
+            return this.model.save({}, { patch: true });
+          }.bind(this));
+        });
+
+        it("updates the model in the collection", function () {
+          var collection = new this.Collection();
+          return collection.fetch().then(function () {
+            expect(collection.toJSON()).to.deep.eql([{
+              id: 1,
+              value: 1,
+              patched: true
+            }]);
+          });
+        });
+      });
+    });
+
+    describe("deleting an existing model", function () {
+      beforeEach(function () {
+        this.server.respondWith('DELETE', '/models/1', function (xhr) {
+          this.storeRequest(xhr);
+          xhr.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify({}));
+        }.bind(this));
+
+        this.model.set('id', 1);
+      });
+
+      describe("for a standalone model", function () {
+        beforeEach(function () {
+          return this.control.store.set('/models/1', { deleted: false }).then(function () {
+            return this.model.destroy();
+          }.bind(this));
+        });
+
+        it("clears the cache", function () {
+          return expect(this.control.store.get('/models/1')).to.be.rejected;
+        });
+
+        it("sends new fetches to the server", function () {
+          var model2 = new this.Model({id: 1});
+          return model2.fetch().then(function () {
+            expect(model2.toJSON()).to.deep.eql({id: -1, value: -1 });
+          }.bind(this));
+        });
+      });
+
+      describe("for a model in a collection", function () {
+        beforeEach(function () {
+          this.collection = new this.Collection(this.model);
+          this.initialData = [{ id: 0 }, { id: 1 }, { id: 2 }];
+          return this.control.store.set(this.collectionKey, this.initialData).then(function () {
+            return this.model.destroy();
+          }.bind(this));
+        });
+
+        it("clears the model from the cached collection", function () {
+          var collection = new this.Collection();
+          return collection.fetch().then(function () {
+            expect(collection.toJSON()).to.deep.eql([{ id: 0 }, { id: 2 }]);
+          });
         });
       });
     });
   });
-
-  describe("deleting an existing model", function () {
-    beforeEach(function () {
-      this.server.respondWith('DELETE', '/models/1', function (xhr) {
-        this.storeRequest(xhr);
-        xhr.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify({}));
-      }.bind(this));
-
-      this.model.set('id', 1);
-    });
-
-    describe("for a standalone model", function () {
-      beforeEach(function () {
-        return this.control.store.set('/models/1', { deleted: false }).then(function () {
-          return this.model.destroy();
-        }.bind(this));
-      });
-
-      it("clears the cache", function () {
-        return expect(this.control.store.get('/models/1')).to.be.rejected;
-      });
-
-      it("sends new fetches to the server", function () {
-        var model2 = new this.Model({id: 1});
-        return model2.fetch().then(function () {
-          expect(model2.toJSON()).to.deep.eql({id: -1, value: -1 });
-        }.bind(this));
-      });
-    });
-
-    describe("for a model in a collection", function () {
-      beforeEach(function () {
-        this.collection = new this.Collection(this.model);
-        this.initialData = [{ id: 0 }, { id: 1 }, { id: 2 }];
-        return this.control.store.set(this.collectionKey, this.initialData).then(function () {
-          return this.model.destroy();
-        }.bind(this));
-      });
-
-      it("clears the model from the cached collection", function () {
-        var collection = new this.Collection();
-        return collection.fetch().then(function () {
-          expect(collection.toJSON()).to.deep.eql([{ id: 0 }, { id: 2 }]);
-        });
-      });
-    });
-  });
-});
+}

--- a/spec/meta-store.spec.js
+++ b/spec/meta-store.spec.js
@@ -26,9 +26,10 @@ describe("MetaStore", function () {
     it("sets the meta for the key when the meta is empty", function () {
       this.metaStore.backend.getItem.withArgs(this.metaStore.key).returns(null);
 
-      this.metaStore.set(this.key, this.meta);
-      expect(this.metaStore.backend.setItem).to.have.been.calledOnce
-        .and.calledWith(this.metaStore.key, this.storedMetaString);
+      return this.metaStore.set(this.key, this.meta).then(function () {
+        expect(this.metaStore.backend.setItem).to.have.been.calledOnce
+          .and.calledWith(this.metaStore.key, this.storedMetaString);
+      }.bind(this));
     });
 
     it("sets the meta for the key when the meta is populated", function () {
@@ -37,9 +38,10 @@ describe("MetaStore", function () {
         .returns(JSON.stringify(alreadyStored));
       var newStoredMeta = _.extend(alreadyStored, this.storedMeta);
 
-      this.metaStore.set(this.key, this.meta);
-      expect(this.metaStore.backend.setItem).to.have.been.calledOnce
-        .and.calledWith(this.metaStore.key, JSON.stringify(newStoredMeta));
+      return this.metaStore.set(this.key, this.meta).then(function () {
+        expect(this.metaStore.backend.setItem).to.have.been.calledOnce
+          .and.calledWith(this.metaStore.key, JSON.stringify(newStoredMeta));
+      }.bind(this));
     });
   });
 
@@ -47,7 +49,7 @@ describe("MetaStore", function () {
     it("returns all metadata", function () {
       this.metaStore.backend.getItem.withArgs(this.metaStore.key)
         .returns(this.storedMetaString);
-      expect(this.metaStore.getAll()).to.eventually.eql(this.storedMeta);
+      return expect(this.metaStore.getAll()).to.eventually.eql(this.storedMeta);
     });
   });
 
@@ -55,15 +57,17 @@ describe("MetaStore", function () {
     it("replaces the metadata, without the provided key", function () {
       this.metaStore.backend.getItem.withArgs(this.metaStore.key)
         .returns(this.storedMetaString);
-      this.metaStore.invalidate(this.key);
-      expect(this.metaStore.backend.setItem).to.have.been.calledOnce
-        .and.calledWith(this.metaStore.key, JSON.stringify({}));
+      return this.metaStore.invalidate(this.key).then(function () {
+        expect(this.metaStore.backend.setItem).to.have.been.calledOnce
+          .and.calledWith(this.metaStore.key, JSON.stringify({}));
+      }.bind(this));
     });
   });
 
   describe("invalidateAll", function () {
     beforeEach(function () {
       this.result = this.metaStore.invalidateAll();
+      return this.result;
     });
 
     it("removes the metadata", function () {

--- a/src/meta-store.js
+++ b/src/meta-store.js
@@ -22,42 +22,49 @@ _.extend(MetaStore.prototype, Hoard.Events, {
   key: 'backbone.hoard.metastore',
 
   set: function (key, meta, options) {
-    var allMetadata = this._get();
-    allMetadata[key] = meta;
-    return this._set(this.key, allMetadata);
+    return this._get(options).then(_.bind(function (allMetadata) {
+      allMetadata[key] = meta;
+      return this._set(this.key, allMetadata);
+    }, this));
   },
 
   get: function (key, options) {
-    var allMetadata = this._get();
-    var meta = allMetadata[key] || {};
-    return Hoard.Promise.resolve(meta);
+    return this._get(options).then(_.bind(function (allMetadata) {
+      return allMetadata[key] || {};
+    }, this));
   },
 
   getAll: function (options) {
-    return Hoard.Promise.resolve(this._get());
+    return this._get(options);
   },
 
   invalidate: function (key, options) {
-    var allMetadata = this._get();
-    delete allMetadata[key];
-    this._set(this.key, allMetadata);
-    return Hoard.Promise.resolve();
+    return this._get(options).then(_.bind(function (allMetadata) {
+      delete allMetadata[key];
+      return this._set(this.key, allMetadata);
+    }, this));
   },
 
-  invalidateAll: function () {
-    this.backend.removeItem(this.key);
-    return Hoard.Promise.resolve();
+  invalidateAll: function (options) {
+    return this.removeItem(this.key, options);
   },
 
-  _get: function () {
-    return JSON.parse(this.backend.getItem(this.key)) || {};
+  _get: function (options) {
+    return this.getItem(this.key, options).then(
+      _.identity,
+      function () {
+        return {};
+      }
+    );
   },
 
   _set: function (key, meta) {
-    return this._setItem(key, meta);
+    return this.setItem(key, meta);
   },
 
-  _setItem: StoreHelpers.proxySetItem
+  getItem: StoreHelpers.proxyGetItem,
+  setItem: StoreHelpers.proxySetItem,
+  removeItem: StoreHelpers.proxyRemoveItem
 });
 
 MetaStore.extend = Hoard._proxyExtend;

--- a/src/store-helpers.js
+++ b/src/store-helpers.js
@@ -1,24 +1,42 @@
 'use strict';
 
 var Hoard = require('./backbone.hoard');
+var _ = require('underscore');
 
 // Convenience methods for stores
 module.exports = {
   proxySetItem: function (key, value) {
-    try {
-      this.backend.setItem(key, JSON.stringify(value));
-      return Hoard.Promise.resolve(value);
-    } catch (e) {
-      return Hoard.Promise.reject(e);
-    }
+    return Hoard.Promise.resolve()
+      .then(_.bind(function () {
+        try {
+          return this.backend.setItem(key, JSON.stringify(value));
+        } catch (e) {
+          return Hoard.Promise.reject(e);
+        }
+      }, this))
+      .then(function () {
+        return value;
+      });
   },
 
   proxyGetItem: function (key, options) {
-    var storedValue = JSON.parse(this.backend.getItem(key));
-    if (storedValue !== null) {
-      return Hoard.Promise.resolve(storedValue);
-    } else {
-      return Hoard.Promise.reject();
-    }
+    return Hoard.Promise.resolve()
+      .then(_.bind(function () {
+        return this.backend.getItem(key);
+      }, this))
+      .then(function (raw) {
+        var storedValue = JSON.parse(raw);
+        if (storedValue !== null) {
+          return storedValue;
+        } else {
+          return Hoard.Promise.reject();
+        }
+      });
+  },
+
+  proxyRemoveItem: function (key, options) {
+    return Hoard.Promise.resolve().then(_.bind(function () {
+      return this.backend.removeItem(key, options);
+    }, this));
   }
 };


### PR DESCRIPTION
Moved all `backend` access to the `StoreHelpers`. Additionally the
backend access is now wrapped in promises, so localStorage and
asynchronous storage access can be handled via swapping out the backend,
rather than overriding methods on Store or MetaStore.

Adding configuration to the Integration tests to allow running them with
different backends. This should help when testing backend adapters for #6.