### PR TITLE
(#24) Replace localStorage with in-memory-store as default backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Promise.all(fetches).then(function () {
 
  - Backbone 1.0.0 - 1.1.2
  - underscore 1.4.4 - 1.7.0
- - `localStorage`
  - An es6-compliant `Promise`
  
 #API
@@ -179,7 +178,7 @@ Returns a `Promise` that resolves if the sync action is successful or rejects if
 ##Store
 
 The `Store` encapsulates all interaction with the backing persistence API. 
-Even though the default implementation uses `localStorage` for persistence, 
+Even though the default implementation uses an api similar to `localStorage` for persistence,
 all interactions with `Store` are asynchronous. 
 This behavior makes it possible to use other types of client-side storage, such as IndexedDB or WebSQL
 
@@ -226,19 +225,20 @@ Otherwise, you will need to configure Hoard with an es6-compliant Promise implem
  
 ##Hoard.backend
 
-By default, Hoard will use `localStorage` to cache data and metadata.
-If support for older browsers is desired, be sure to use a polyfill. 
-`Hoard.backend` can also be set to `sessionStorage`, or anything matching a `localStorage` API supporting:
+By default, Hoard will use an in-memory store to cache data and metadata.
+Using an in-memory store ensures that the cache will never be stale on a page refresh.
+If persistence beyond page refreshes is desired, `Hoard.backend` can also be set to
+`localStorage`, `sessionStorage`, or anything matching a `localStorage` API supporting:
 
  - `backend.setItem`
  - `backend.getItem`
  - `backend.removeItem`
  
  ```js
- // ex: using sessionStorage instead of local storage
- // Make Stores use sessionStorage unless explicitly told to use something else
- Hoard.backend = sessionStorage;
+ // ex: using localStorage instead of the in-memory store
+ // Make Stores use localStorage unless explicitly told to use something else
+ Hoard.backend = localStorage;
  
- // Make all instantces of LocalStore use localStorage
- var LocalStore = Hoard.Store.extend({ backend: localStorage });
+ // Make all instantces of SessionStore use SessionStorage
+ var SessionStore = Hoard.Store.extend({ backend: sessionStorage });
  ```

--- a/gulp/tasks/test-integration.js
+++ b/gulp/tasks/test-integration.js
@@ -7,6 +7,6 @@ var argv = require('yargs').argv;
 gulp.task('test:integration', ['test:integration:bundle'], function (done) {
   karma.start({
     configFile: process.env.PWD + '/karma.conf.js',
-    singleRun: !argv.karmaDebug
+    singleRun: !argv.tdd
   }, done);
 });

--- a/recipe/time-sensitive-policy.js
+++ b/recipe/time-sensitive-policy.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Policy = require('src/policy');
+var Policy = require('../src/policy');
 
 module.exports = Policy.extend({
   // How long, in milliseconds, should a cached item be considered 'fresh'?

--- a/spec/backend.spec.js
+++ b/spec/backend.spec.js
@@ -1,0 +1,85 @@
+'use strict';
+
+var Backend = require('src/backend');
+
+describe("Backend", function () {
+  beforeEach(function () {
+    this.backend = new Backend();
+    this.key = 'key';
+    this.value = JSON.stringify({ value: true });
+  });
+
+  describe("when created", function () {
+    it("storage is empty", function () {
+      expect(this.backend.storage).to.eql({});
+    });
+
+    it("has size 0", function () {
+      expect(this.backend.size).to.equal(0);
+    });
+  });
+
+  describe("setItem", function () {
+    describe("when there is space available", function () {
+      beforeEach(function () {
+        this.backend.setItem(this.key, this.value);
+      });
+
+      it("adds the item to storage under key", function () {
+        expect(this.backend.storage[this.key]).to.eql(this.value);
+      });
+
+      it("increases the size by the length of the value", function () {
+        expect(this.backend.size).to.equal(this.value.length);
+      });
+    });
+
+    describe("when the cache is full", function () {
+      beforeEach(function () {
+        this.backend.maxSize = 0;
+        this.setItem = this.backend.setItem.bind(this.backend, this.key, this.value);
+      });
+
+      it("throws an error", function () {
+        expect(this.setItem).to.throw();
+      });
+
+      it("does not set the value in storage", function () {
+        expect(this.backend.getItem(this.key)).to.be.null;
+      });
+
+      it("does not adjust the size", function () {
+        expect(this.backend.size).to.equal(0);
+      });
+    });
+  });
+
+  describe("getItem", function () {
+    beforeEach(function () {
+      this.backend.setItem(this.key, this.value);
+    });
+
+    it("returns the value stored under the given key", function () {
+      expect(this.backend.getItem(this.key)).to.eql(this.value);
+    });
+
+    it("returns null if nothing is stored under the given key", function () {
+      expect(this.backend.getItem('not-key')).to.be.null;
+    });
+  });
+
+  describe("removeItem", function () {
+    beforeEach(function () {
+      this.backend.setItem(this.key, this.value);
+      this.backend.removeItem(this.key);
+    });
+
+    it("removes the item from storage", function () {
+      expect(this.backend.getItem(this.key)).to.be.null;
+    });
+
+    it("adjusts the size", function () {
+      expect(this.backend.size).to.equal(0);
+    });
+  });
+});

--- a/spec/integration/async-local-storage.js
+++ b/spec/integration/async-local-storage.js
@@ -20,5 +20,10 @@ module.exports = {
     return Hoard.Promise.resolve().then(function () {
       return localStorage.removeItem(key);
     });
+  },
+
+  // only used by spec teardown
+  clear: function () {
+    localStorage.clear();
   }
 };

--- a/spec/integration/read.int-spec.js
+++ b/spec/integration/read.int-spec.js
@@ -6,6 +6,10 @@ var Hoard = require('src/backbone.hoard');
 
 module.exports = function (storageName, storage) {
   describe("Reading with " + storageName, function () {
+    afterEach(function () {
+      return storage.clear();
+    });
+
     beforeEach(function () {
       this.sinon.stub(Hoard, 'backend', storage);
       this.control = new Hoard.Control();
@@ -69,7 +73,15 @@ module.exports = function (storageName, storage) {
         });
 
         it("populates the cache", function () {
-          expect(localStorage.getItem('/id-plus-one/1')).to.equal(JSON.stringify({ id:1, value: 2 }));
+          var storedItem = storage.getItem('/id-plus-one/1');
+          var expectedJSON = JSON.stringify({id: 1, value: 2});
+
+          //account for synchronous and asynchronous storage
+          if (storedItem.then) {
+            return expect(storedItem).to.eventually.equal(expectedJSON);
+          } else {
+            expect(storedItem).to.equal(expectedJSON);
+          }
         });
       });
 
@@ -88,7 +100,7 @@ module.exports = function (storageName, storage) {
             d2.resolve();
           }.bind(this));
 
-          return Promise.all([d1.prmoise, d2.promise]).then(function () {
+          return Promise.all([d1.promise, d2.promise]).then(function () {
             return Promise.all([this.m1Promise, this.m2Promise]);
           }.bind(this));
         });

--- a/spec/integration/setup.js
+++ b/spec/integration/setup.js
@@ -14,6 +14,8 @@ var asyncLocalStorage = require('./async-local-storage');
 var readSpecs = require('./read.int-spec.js');
 var writeSpecs = require('./write.int-spec.js');
 
+readSpecs('Backend', Hoard.backend);
+writeSpecs('Backend', Hoard.backend);
 readSpecs('localStorage', localStorage);
 writeSpecs('localStorage', localStorage);
 readSpecs('asyncLocalStorage', asyncLocalStorage);
@@ -41,5 +43,4 @@ beforeEach(function () {
 afterEach(function () {
   this.server.restore();
   this.sinon.restore();
-  localStorage.clear();
 });

--- a/spec/integration/write.int-spec.js
+++ b/spec/integration/write.int-spec.js
@@ -6,6 +6,10 @@ var Hoard = require('src/backbone.hoard');
 
 module.exports = function (storageName, storage) {
   describe("Writing with " + storageName, function () {
+    afterEach(function () {
+      return storage.clear();
+    });
+
     beforeEach(function () {
       this.sinon.stub(Hoard, 'backend', storage);
       this.control = new Hoard.Control();
@@ -259,4 +263,4 @@ module.exports = function (storageName, storage) {
       });
     });
   });
-}
+};

--- a/src/backbone.hoard.js
+++ b/src/backbone.hoard.js
@@ -1,11 +1,14 @@
 'use strict';
 
 var Backbone = require('backbone');
+var Backend = require('./backend');
 
 var Hoard = {
   Promise: function () {
     throw new TypeError('An ES6-compliant Promise implementation must be provided');
   },
+
+  backend: new Backend(),
 
   sync: Backbone.sync,
 

--- a/src/backend.js
+++ b/src/backend.js
@@ -1,0 +1,54 @@
+'use strict';
+
+var _ = require('underscore');
+
+// Mimic the API of localStorage
+// All operations expect JSON strings to be stored and returned
+var Backend = function () {
+  this.clear();
+};
+
+_.extend(Backend.prototype, {
+  // around 5MB, matching common localStorage limit
+  maxSize: 5000000,
+
+  // Store the given value and update the size
+  setItem: function (key, value) {
+    if (this.size + value.length > this.maxSize) {
+      // Notify Hoard that the cache is full.
+      // This will trigger a cache invalidation.
+      throw new Error("On-Page Cache size exceeded");
+    } else {
+      this.storage[key] = value;
+      this.size += value.length;
+    }
+  },
+
+  // Get the item with the given key from the cache
+  // or null if the item is not found
+  getItem: function (key) {
+    var value = this.storage[key];
+    if (_.isUndefined(value)) {
+      value = null;
+    }
+    return value;
+  },
+
+  // Remove the item with the given key
+  // And update the size of the cache
+  removeItem: function (key) {
+    var value = this.getItem(key);
+    delete this.storage[key];
+    if (value != null) {
+      this.size -= value.length;
+    }
+    return value;
+  },
+
+  clear: function () {
+    this.storage = {};
+    this.size = 0;
+  }
+});
+
+module.exports = Backend;

--- a/src/build/backbone.hoard.bundle.js
+++ b/src/build/backbone.hoard.bundle.js
@@ -11,10 +11,6 @@ if (typeof Promise !== 'undefined') {
   Hoard.Promise = Promise;
 }
 
-if (typeof localStorage !== 'undefined') {
-  Hoard.backend = localStorage;
-}
-
 var previousHoard = Backbone.Hoard;
 Backbone.Hoard = Hoard;
 Hoard.noConflict = function () {


### PR DESCRIPTION
This addresses the common case where people want the perf boost, but
don't want to worry about cache eviction.

Additionally tweak time-sensitive-cache recipe to allow for requiring
it directly.

@jmeas: you might be interested in this one.