### PR TITLE
(#6) Adapt Hoard to be compabible with localforage

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,4 +241,8 @@ If persistence beyond page refreshes is desired, `Hoard.backend` can also be set
  
  // Make all instantces of SessionStore use SessionStorage
  var SessionStore = Hoard.Store.extend({ backend: sessionStorage });
+
+ // Using mozilla/localForage
+ localforage.setDriver(localforage.INDEXEDDB);
+ var LocalForageStore = Hoard.Store.extend({ backend: localforage });
  ```

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,6 +15,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
+      'node_modules/localforage/dist/localforage.js',
       'node_modules/sinon/pkg/sinon.js',
       'spec/integration/spec.bundle.js'
     ],

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "karma-chrome-launcher": "^0.1.5",
     "karma-mocha": "^0.1.9",
     "karma-mocha-reporter": "^0.3.2",
+    "localforage": "^1.2.2",
     "mocha": "^1.21.4",
     "sinon": "^1.10.3",
     "sinon-chai": "^2.5.0",

--- a/spec/integration/setup.js
+++ b/spec/integration/setup.js
@@ -21,6 +21,13 @@ writeSpecs('localStorage', localStorage);
 readSpecs('asyncLocalStorage', asyncLocalStorage);
 writeSpecs('asyncLocalStorage', asyncLocalStorage);
 
+// loaded by karma
+localforage.config({
+  driver: localforage.INDEXEDDB
+});
+readSpecs('localforage', localforage);
+writeSpecs('localforage', localforage);
+
 window.expect = chai.expect;
 chai.use(sinonChai);
 chai.use(chaiAsPromised);

--- a/src/store-helpers.js
+++ b/src/store-helpers.js
@@ -36,7 +36,7 @@ module.exports = {
 
   proxyRemoveItem: function (key, options) {
     return Hoard.Promise.resolve().then(_.bind(function () {
-      return this.backend.removeItem(key, options);
+      return this.backend.removeItem(key);
     }, this));
   }
 };


### PR DESCRIPTION
With localforage support, Hoard supports a heavily supported API that
includes easy access to IndexedDB