### PR TITLE
(#33) Add a Policy recipe to handle jQuery 'data' params

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,12 @@ The returned method has all of the same properties as the control's `sync` metho
 ##Policy
 
 The `Policy` determines meta information about cached items.
-The default implementation is bare-bones. Look at `recipes/time-sensitive-policy`
-for a more interesting policy implementation.
+The default implementation is bare-bones.
+
+Consider:
+
+* `recipes/time-sensitive-policy` for a policy featuring time-based eviction.
+* `recipes/jquery-data-params-policy` for a policy knowledgeable about jQuery data params on read
 
 ###Policy#getUrl(model, options, options)
 

--- a/recipe/jquery-data-params-policy.js
+++ b/recipe/jquery-data-params-policy.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var Policy = require('../src/policy');
+var _ = require('underscore');
+
+/**
+ * This Policy handles converting jQuery `options.data` to a queryParam string
+ * The given implementation only works on immediately serializable parameters
+ *   and probaly does not account for everything jQuery handles
+ * (That's partially why this is a recipe and not core code)
+ */
+module.exports = Policy.extend({
+  getKey: function (model, method, options) {
+    var data, queryParams, paramKeys, startOfQuery;
+    var key = Policy.prototype.getKey.call(this, model, method, options);
+
+    // Convert options.data to query params with a GET request
+    if (method === 'read') {
+      data = _.result(options, 'data');
+
+      // If data is an object, convert to a query string
+      // Otherwise, accept that data is a string and just use that
+      if (_.isObject(data)) {
+        // Sort for consistency to ensure cache hits when appropriate
+        paramKeys = _.keys(data).sort();
+        queryParams = _.reduce(paramKeys, function (memo, key) {
+          var value = data[key];
+          return memo + '&' + key + '=' + value;
+        }, '');
+      } else {
+        queryParams = data;
+      }
+    }
+
+    // If we have query params, add them
+    if (queryParams) {
+      startOfQuery = queryParams.charAt(0);
+      // If no existing query string, start one
+      // else, append
+      if (key.indexOf('?') === -1) {
+        if (startOfQuery === '&') {
+          queryParams = queryParams.slice(1);
+        }
+        key += '?' + queryParams;
+      } else {
+        if (startOfQuery !== '&') {
+          queryParams = '&' + queryParams;
+        }
+        key += queryParams;
+      }
+    }
+
+    return key;
+  }
+});

--- a/recipe/spec/jquery-data-params-policy.spec.js
+++ b/recipe/spec/jquery-data-params-policy.spec.js
@@ -1,0 +1,76 @@
+'use strict';
+
+var Backbone = require('backbone');
+var ParamsPolicy = require('recipe/jquery-data-params-policy');
+
+describe("JqueryDataParamsPolicy", function () {
+  beforeEach(function () {
+    this.model = new Backbone.Model();
+    this.policy = new ParamsPolicy();
+    this.model.url = '/model';
+    this.options = {
+      data: { a: 1, b: 7 }
+    };
+  });
+
+  describe("getKey", function () {
+    it("adds the `data` option as query params", function () {
+      var key = this.policy.getKey(this.model, 'read', this.options);
+      expect(key).to.equal('/model?a=1&b=7');
+    });
+
+    it("puts query params in alphabetical order", function () {
+      this.options.data = { b: 7, a: 1 };
+      var key = this.policy.getKey(this.model, 'read', this.options);
+      expect(key).to.equal('/model?a=1&b=7');
+    });
+
+    it("extends an existing query string", function () {
+      this.model.url = '/model?param=true';
+      var key = this.policy.getKey(this.model, 'read', this.options);
+      expect(key).to.equal('/model?param=true&a=1&b=7');
+    });
+
+    it("appends data if data is a string", function () {
+      this.options.data = 'd=4&c=7';
+      var key = this.policy.getKey(this.model, 'read', this.options);
+      expect(key).to.equal('/model?d=4&c=7');
+    });
+
+    it("handles an empty data hash", function () {
+      this.options.data = {};
+      var key = this.policy.getKey(this.model, 'read', this.options);
+      expect(key).to.equal('/model');
+    });
+
+    it("handles options without data", function () {
+      var key = this.policy.getKey(this.model, 'read', {});
+      expect(key).to.equal('/model');
+    });
+
+    it("handles undefined options", function () {
+      var key = this.policy.getKey(this.model, 'read');
+      expect(key).to.equal('/model');
+    });
+
+    it("does not add query params for a create", function () {
+      var key = this.policy.getKey(this.model, 'create', this.options);
+      expect(key).to.equal('/model');
+    });
+
+    it("does not add query params for a update", function () {
+      var key = this.policy.getKey(this.model, 'create', this.options);
+      expect(key).to.equal('/model');
+    });
+
+    it("does not add query params for a patch", function () {
+      var key = this.policy.getKey(this.model, 'patch', this.options);
+      expect(key).to.equal('/model');
+    });
+
+    it("does not add query params for a delete", function () {
+      var key = this.policy.getKey(this.model, 'patch', this.options);
+      expect(key).to.equal('/model');
+    });
+  });
+});


### PR DESCRIPTION
When issuing a GET request with jQuery, options.data will be translated
to query params and appended to the url. This policy simulates that
behavior.